### PR TITLE
Fix type declaration for attrs

### DIFF
--- a/lib/ledger_sync/domains/operation/transition.rb
+++ b/lib/ledger_sync/domains/operation/transition.rb
@@ -12,8 +12,7 @@ module LedgerSync
             required(:model_name).filled(:string)
             required(:id).filled(:integer)
             required(:event).value(:string)
-            required(:attrs).maybe(:hash)
-            required(:attrs).maybe(:array)
+            required(:attrs).maybe(%i[hash array])
             required(:limit).value(:hash)
           end
         end


### PR DESCRIPTION
Before, `attrs` could only be blank or an array, not a hash, as it got overridden.
```
c= LedgerSync::Domains::Operation::Transition::Contract.new
=> #<LedgerSync::Domains::Operation::Transition::Contract schema=#<Dry::Schema::Params keys=["model_name"...
c.call(model_name: "Model", id: 1, event: "Event", limit: {}, attrs: "ssss")
=> #<Dry::Validation::Result{:model_name=>"Model", :id=>1, :event=>"Event", :attrs=>"ssss", :limit=>{}} errors={:attrs=>["must be an array"]}>
c.call(model_name: "Model", id: 1, event: "Event", limit: {}, attrs: [])
=> #<Dry::Validation::Result{:model_name=>"Model", :id=>1, :event=>"Event", :attrs=>[], :limit=>{}} errors={}>
c.call(model_name: "Model", id: 1, event: "Event", limit: {}, attrs: {})
=> #<Dry::Validation::Result{:model_name=>"Model", :id=>1, :event=>"Event", :attrs=>{}, :limit=>{}} errors={:attrs=>["must be an array"]}>
```
After, `attrs` can be either blank, an array or a hash.
```
c= LedgerSync::Domains::Operation::Transition::Contract.new
=> #<LedgerSync::Domains::Operation::Transition::Contract schema=#<Dry::Schema::Params keys=["model_name"...
c.call(model_name: "Model", id: 1, event: "Event", limit: {}, attrs: "ssss")
=> #<Dry::Validation::Result{:model_name=>"Model", :id=>1, :event=>"Event", :attrs=>"ssss", :limit=>{}} errors={:attrs=>["must be a hash or must be an array"]}>
c.call(model_name: "Model", id: 1, event: "Event", limit: {}, attrs: [])
=> #<Dry::Validation::Result{:model_name=>"Model", :id=>1, :event=>"Event", :attrs=>[], :limit=>{}} errors={}>
c.call(model_name: "Model", id: 1, event: "Event", limit: {}, attrs: {})
=> #<Dry::Validation::Result{:model_name=>"Model", :id=>1, :event=>"Event", :attrs=>{}, :limit=>{}} errors={}>
```
